### PR TITLE
fix unicode issue on windows (python3.11)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from setuptools import find_packages, setup
 
 with open('README.md', encoding="utf-8") as f:


### PR DESCRIPTION
This PR resolves a UnicodeDecodeError that occurs when installing the package on Windows systems using pip. The issue stems from:

- A missing UTF-8 encoding declaration in `setup.py`, causing Python to fall back to the default Windows encoding (`cp1252`), which fails to decode due to character (`ā`) in the `author` field.

### Changes:
- Added `# -*- coding: utf-8 -*-` at the top of `setup.py`

With these changes, the package installs successfully on Windows using Python 3.11+ and pip.
